### PR TITLE
Fix: add N/A to blank cells & keep alive on google api errors

### DIFF
--- a/internal/goat/goat.go
+++ b/internal/goat/goat.go
@@ -95,12 +95,13 @@ func AggregateExcelDataComms() {
 						fileCellValue = "N/A"
 					}
 				}
-				if fileCellValue == "" {
-					continue // skip empty cells
-				}
 
 				if transfer.DstToCell == "" {
-					outputFile.SetCellValue(outputFile.GetSheetName(0), transfer.DstFromCell, fileCellValue)
+					if fileCellValue == "" {
+						outputFile.SetCellValue(outputFile.GetSheetName(0), transfer.DstFromCell, "N/A")
+					} else {
+						outputFile.SetCellValue(outputFile.GetSheetName(0), transfer.DstFromCell, fileCellValue)
+					}
 				} else {
 					dstFromLetter, dstFromNumber := parseCell(transfer.DstFromCell)
 					_, dstToNumber := parseCell(transfer.DstToCell)
@@ -110,14 +111,25 @@ func AggregateExcelDataComms() {
 							if len(strings.Split(outputCellValue, " ")) >= 2 {
 								continue
 							}
+							if fileCellValue == "" {
+								fileCellValue = "N/A"
+							}
 							outputCellValue += fmt.Sprintf(" %s", fileCellValue)
 							outputFile.SetCellValue(outputFile.GetSheetName(0), fmt.Sprintf("%s%d", dstFromLetter, row), outputCellValue)
 							break
 						}
 						if outputCellValue == "" {
-							outputFile.SetCellValue(outputFile.GetSheetName(0), fmt.Sprintf("%s%d", dstFromLetter, row), fileCellValue)
-							break
+							bColValue, _ := outputFile.GetCellValue(outputFile.GetSheetName(0), fmt.Sprintf("%s%d", "B", row))
+							if (srcCol == "W" || srcCol == "X") && fileCellValue == "" && bColValue != "" {
+								outputFile.SetCellValue(outputFile.GetSheetName(0), fmt.Sprintf("%s%d", dstFromLetter, row), "N/A")
+							} else {
+								outputFile.SetCellValue(outputFile.GetSheetName(0), fmt.Sprintf("%s%d", dstFromLetter, row), fileCellValue)
+								break
+							}
 						} else if row == dstToNumber {
+							if fileCellValue == "" {
+								fileCellValue = "N/A"
+							}
 							overflowCellData, _ := outputFile.GetCellValue(outputFile.GetSheetName(0), transfer.OverflowCell)
 							overflowCellData += fmt.Sprintf(", %s", fileCellValue)
 							outputFile.SetCellValue(outputFile.GetSheetName(0), transfer.OverflowCell, overflowCellData)

--- a/internal/goat/goat.go
+++ b/internal/goat/goat.go
@@ -348,7 +348,7 @@ func AddAISummary() {
 			contents = strings.ReplaceAll(contents, advisorName, constants.ADVISOR_NAME)
 
 			prompt := fmt.Sprintf("%s\n%s", promptPrefix, contents)
-			response, err := gemini.WaitForRateLimit(prompt)
+			response, err := gemini.WaitForErrors(prompt)
 			if err != nil {
 				logger.Error("Error prompting Gemini AI: %+v\n", "err", err)
 				log.Printf("Error prompting Gemini AI: %+v\n", err)


### PR DESCRIPTION
script now adds N/A to destination cells instead of empty string from blank source cells .
script now keeps running even after getting a 500 internal error or other errors from google gemini api.